### PR TITLE
Corrects, command order in help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+.vscode/

--- a/run.py
+++ b/run.py
@@ -13,7 +13,7 @@ ALL_CODE = SOURCE_CODE + TEST_CODE
 
 def arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description='Run linter, static type checker, tests'
+        description='Run static type checker, linter, tests'
     )
 
     subparsers = parser.add_subparsers(dest='func', help='sub-commands')


### PR DESCRIPTION
Fixes the command order with the description provided while running `python run.py --help`.

**BEFORE**
```
usage: run.py [-h] {typecheck,lint,test} ...

Run linter, static type checker, tests
...
```

**AFTER**
```
usage: run.py [-h] {typecheck,lint,test} ...

Run static type checker, linter, tests
...
```